### PR TITLE
Fix Vagrant Deployment

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,10 +18,9 @@ Requires:
 * Vagrant
 
 1. Before startup, clear logs and remove naming service data folder.
-1. Run `vagrant up` to startup the naming service and the raid node. Note, that vagrant up will pull on the first startup the latest source code from GitHub and build a new jar.
+1. Run `vagrant up` to startup the naming service, the raid node and all the floor nodes (floor0 through floor2). Note, that vagrant up will pull on the first startup the latest source code from GitHub and build a new jar.
   * The raid node vm will also compile the FBaseExampleClients jars on first startup.
   * The raid vm will use Registration.jar to register the other floor nodes at the naming service.
-1. Run `vagrant up floor0` to startup the ground level floor node. Do the same for floor1 and floor2 (you can do this in parallel).
 1. Create the keygroups (`vagrant provision raid --provision-with run_client_keygroupBootstrap`), make sure that it worked, otherwise run again.
 1. Tell every floor node to update its local keygroup config for each keygroup created (because otherwise they do not know about them, note: raid knows because of above already about keygroups): `vagrant provision floor0 --provision-with run_client_keygroupUpdateSubscriptions` (also for floor0, floor1, floor2)
 1. Start generation of records for floor nodes: `vagrant provision floor0 --provision-with run_client_addRecords` (also for floor0, floor1, floor2)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
 
   # startup instances
   config.vm.define "namingService" do |ns|
-      ns.vm.box = "ubuntu/trusty64"
+      ns.vm.box = "ubuntu/xenial64"
       ns.vm.network "private_network", ip: "192.168.0.200", bridge: "en0: WLAN (AirPort)"
 
       ns.vm.provision "shell", path: "vagrantfiles/build_github_repo.sh", args: ["FBaseNamingService", "https://github.com/OpenFogStack/FBaseNamingService.git"]
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "raid" do |raid|
-        raid.vm.box = "ubuntu/trusty64"
+        raid.vm.box = "ubuntu/xenial64"
         raid.vm.network "private_network", ip: "192.168.0.100", bridge: "en0: WLAN (AirPort)"
 
         raid.vm.provision "shell", path: "vagrantfiles/build_github_repo.sh", args: ["FBase", "https://github.com/OpenFogStack/FBase"]
@@ -55,7 +55,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "floor0", autostart: true do |floor0|
-        floor0.vm.box = "ubuntu/trusty64"
+        floor0.vm.box = "ubuntu/xenial64"
         floor0.vm.network "private_network", ip: "192.168.0.50", bridge: "en0: WLAN (AirPort)"
 
         floor0.vm.provision "shell", path: "vagrantfiles/build_github_repo.sh", args: ["FBase", "https://github.com/OpenFogStack/FBase"]
@@ -67,7 +67,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "floor1", autostart: true do |floor1|
-        floor1.vm.box = "ubuntu/trusty64"
+        floor1.vm.box = "ubuntu/xenial64"
         floor1.vm.network "private_network", ip: "192.168.0.51", bridge: "en0: WLAN (AirPort)"
 
         floor1.vm.provision "shell", path: "vagrantfiles/build_github_repo.sh", args: ["FBase", "https://github.com/OpenFogStack/FBase"]
@@ -79,7 +79,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "floor2", autostart: true do |floor2|
-        floor2.vm.box = "ubuntu/trusty64"
+        floor2.vm.box = "ubuntu/xenial64"
         floor2.vm.network "private_network", ip: "192.168.0.52", bridge: "en0: WLAN (AirPort)"
 
         floor2.vm.provision "shell", path: "vagrantfiles/build_github_repo.sh", args: ["FBase", "https://github.com/OpenFogStack/FBase"]

--- a/vagrantfiles/setup_os_and_tools.sh
+++ b/vagrantfiles/setup_os_and_tools.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Update everything
-sudo apt-get -y upgrade
 sudo apt-get -y update
+sudo apt-get -y upgrade
 
 # Set Encoding
 sudo echo "LANG=en_US.UTF-8" >> /etc/environment
@@ -18,12 +18,7 @@ sudo apt-get -y install git
 
 ### Install java 8
 echo "INSTALLING JAVA 8"
-sudo add-apt-repository -y ppa:webupd8team/java
-sudo apt-get update
-sudo apt-get -y upgrade
-echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
-echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
-sudo apt-get -y install oracle-java8-installer
+sudo apt-get -y install openjdk-8-jdk
 
 ### Install maven
 echo "INSTALLING MAVEN"


### PR DESCRIPTION
Oracle Java 8 JDK can no longer be installed automatically (see [here](http://www.webupd8.org/2012/09/install-oracle-java-8-in-ubuntu-via-ppa.html)), need to use OpenJDK 8 instead, which requires Ubuntu Xenial (16) instead of Trusty (14). Updated Vagrantfile and setup script accordingly